### PR TITLE
Dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "numpy-flint"
-version = "0.2.3"
+version = "0.2.4"
 authors = [{name="Jef Wagner", email="jefwagner@gmail.com"}]
 readme = "readme.md"
 # license = "LGPL-3.0-or-later"

--- a/src/numpy_flint.c
+++ b/src/numpy_flint.c
@@ -349,7 +349,8 @@ static PyObject* pyflint_getstate(PyObject* self, PyObject* args) {
 static PyObject* pyflint_setstate(PyObject* self, PyObject* args) {
     flint *f;
     f = &(((PyFlint*) self)->obval);
-    if (PyArg_ParseTuple(args, "ddd:setstate", &(f->a), &(f->b), &(f->v))) {
+    if (!PyArg_ParseTuple(args, "(ddd):setstate", &(f->a), &(f->b), &(f->v))) {
+        PyErr_SetString(PyExc_ValueError, "Could not unpack state tuple");
         return NULL;
     }
     Py_INCREF(Py_None);

--- a/src/numpy_flint.c
+++ b/src/numpy_flint.c
@@ -930,9 +930,9 @@ static void npyflint_copyswapn(void* dst, npy_intp dstride,
         // Else we make a call for each double in the struct
         descr->f->copyswapn(&(_dst->a), dstride, &(_src->a), sstride, 
                             n, swap, arr);
-        descr->f->copyswapn(&(_dst->b), dstride, &(_src->a), sstride, 
+        descr->f->copyswapn(&(_dst->b), dstride, &(_src->b), sstride, 
                             n, swap, arr);
-        descr->f->copyswapn(&(_dst->v), dstride, &(_src->a), sstride, 
+        descr->f->copyswapn(&(_dst->v), dstride, &(_src->v), sstride, 
                             n, swap, arr);
     }
     Py_DECREF(descr);

--- a/test.ipynb
+++ b/test.ipynb
@@ -34,29 +34,70 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "a = np.arange(10, dtype=flint)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], dtype=flint)"
+       "array([[0.0, 1.0, 2.0, 3.0],\n",
+       "       [4.0, 5.0, 6.0, 7.0],\n",
+       "       [8.0, 9.0, 10.0, 11.0]], dtype=flint)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "np.array([flint(a) for a in range(10)])"
+    "a = np.arange(12, dtype=flint).reshape((3,4))\n",
+    "a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[3.0, 3.0, 3.0, 3.0],\n",
+       "       [3.0, 3.0, 3.0, 3.0],\n",
+       "       [3.0, 3.0, 3.0, 3.0]], dtype=flint)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bb = flint(3.0)\n",
+    "bb.interval = 2.0, 4.0, 3.0\n",
+    "b = np.full((3,4), bb, dtype=flint)\n",
+    "b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1.0, 2.0, 1.5)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cc = bb\n",
+    "cc.__setstate__((1.0,2.0,1.5))\n",
+    "cc.__getstate__()"
    ]
   },
   {

--- a/tests/test_flint.py
+++ b/tests/test_flint.py
@@ -89,6 +89,39 @@ class TestProperties(unittest.TestCase):
         self.assertEqual(2, x.b)
         self.assertEqual(1.75, x.v)
 
+class TestState:
+
+    def test_getstate(self):
+        x = flint(1.5)
+        x.interval = 1,2
+        state = x.__getstate__()
+        assert isinstance(state, tuple)
+        assert len(state) == 3
+        assert state[0] == x.a
+        assert state[1] == x.b
+        assert state[2] == x.v
+
+    def test_setstate(self):
+        x = flint(0)
+        x.__setstate__((1.0, 2.0, 1.5))
+        assert x.a == 1.0
+        assert x.b == 2.0
+        assert x.v == 1.5
+
+    def test_reduce(self):
+        x = flint(1.5)
+        x.interval = 1,2
+        r = x.__reduce__()
+        assert isinstance(r, tuple)
+        assert len(r) == 2
+        assert isinstance(r[0], type)
+        assert r[0] == type(x)
+        assert isinstance(r[1], tuple)
+        assert len(r[1]) == 3
+        assert r[1][0] == x.a
+        assert r[1][1] == x.b
+        assert r[1][2] == x.v
+
 
 class TestFloatSpecialValues(unittest.TestCase):
     """Test the query functions for the float special value checks"""

--- a/tests/test_flint.py
+++ b/tests/test_flint.py
@@ -943,3 +943,61 @@ class TestInvHyperTrigMath(unittest.TestCase):
         self.assertTrue(np.isnan(y.a))
         self.assertTrue(np.isnan(y.b))
         self.assertTrue(np.isnan(y.v))
+
+
+class TestNumpyArray():
+
+    def test_array(self):
+        a = np.array([1], dtype=flint)
+        assert isinstance(a, np.ndarray)
+        assert a.dtype == flint
+        assert isinstance(a[0], flint)
+        assert a[0].a == np.nextafter(1,-np.inf)
+        assert a[0].b == np.nextafter(1, np.inf)
+        assert a[0].v == 1.0
+
+    def test_zeros(self):
+        a = np.zeros((1,), dtype=flint)
+        assert isinstance(a, np.ndarray)
+        assert a.dtype == flint
+        assert isinstance(a[0], flint)
+        assert a[0].a == 0.0
+        assert a[0].b == 0.0
+        assert a[0].v == 0.0
+
+    def test_fill(self):
+        x = flint(1.5)
+        x.interval = 1,2
+        a = np.full((3,4), x, dtype=flint)
+        assert isinstance(a, np.ndarray)
+        assert a.dtype == flint
+        for val in np.nditer(a):
+            item = val.item()
+            assert isinstance(item, flint)
+            assert item.a == x.a
+            assert item.b == x.b
+            assert item.v == x.v
+
+    def test_copy_row(self):
+        a = np.zeros((3,3), dtype=flint)
+        b = np.arange(1,4, dtype=flint)
+        zero_row = np.zeros((3,))
+        assert np.alltrue( a[0] == zero_row )
+        assert np.alltrue( a[1] == zero_row )
+        assert np.alltrue( a[2] == zero_row )
+        a[1] = b
+        assert np.alltrue( a[0] == zero_row )
+        assert np.alltrue( a[1] == b )
+        assert np.alltrue( a[2] == zero_row )
+
+    def test_copy_col(self):
+        a = np.zeros((3,3), dtype=flint)
+        b = np.arange(1,4, dtype=flint)
+        zero_row = np.zeros((3,))
+        assert np.alltrue( a[:,0] == zero_row )
+        assert np.alltrue( a[:,1] == zero_row )
+        assert np.alltrue( a[:,2] == zero_row )
+        a[:,1] = b
+        assert np.alltrue( a[:,0] == zero_row )
+        assert np.alltrue( a[:,1] == b )
+        assert np.alltrue( a[:,2] == zero_row )


### PR DESCRIPTION
Fixed two errors in flint-implementation
* Fixed __setstate__ to properly read tuple output of __getstate__ and fixed error reporting when, invalid
* Fixed copyswapn to properly copy all elements of the flints, not just the 'a' elements
Added test cases covering those two instances as well